### PR TITLE
Fixes height of country dropdown

### DIFF
--- a/CSS/Search.css
+++ b/CSS/Search.css
@@ -126,7 +126,6 @@
 
 .city-result{
     display: grid;
-    grid-template-rows: repeat(4,1fr);
     gap: 5px;
 }
 


### PR DESCRIPTION
Removed from class .hidden-city-result:
grid-template-rows: repeat(4,1fr);

Fixes #184 